### PR TITLE
Fix(tasks/detail): Task detail is now fully responsive. 

### DIFF
--- a/apps/web/src/app/shared/styles/elements.scss
+++ b/apps/web/src/app/shared/styles/elements.scss
@@ -40,8 +40,8 @@ form {
     display: grid;
     grid-template-columns: 1fr;
     grid-template-rows: auto;
-    max-height: 740px;
     max-width: 592px;
+    max-height: 740px;
     margin: 0px auto;
 
     border: 1px solid var(--app-border-primary);

--- a/apps/web/src/app/tasks/components/task-detail/task-detail.component.scss
+++ b/apps/web/src/app/tasks/components/task-detail/task-detail.component.scss
@@ -2,7 +2,6 @@
 
 .container {
     display: grid;
-    justify-content: center;
 }
 
 // Mark as Complete
@@ -40,10 +39,12 @@
 
 task-detail {
     box-sizing: border-box;
+    width: 100%;
+    max-width: 592px;
 
-    width: 592px;
     height: 585px;
     padding: 56px;
+    margin: 0px auto;
 
     background-color: white;
     border: 1px solid #eaedf3;
@@ -52,12 +53,9 @@ task-detail {
 
 @media (max-width: 768px) {
     task-detail {
-        width: 100%;
-        max-width: 592px;
+        min-width: 375px;
         height: 496px;
-
         padding: 24px;
-        margin-bottom: 164px;
     }
 
     .mob-none {

--- a/apps/web/src/app/tasks/components/task-detail/task-detail.component.ts
+++ b/apps/web/src/app/tasks/components/task-detail/task-detail.component.ts
@@ -13,6 +13,8 @@ export class TaskDetailComponent implements OnInit {
 
     id: string;
 
+    name: string;
+
     constructor(
         private route: ActivatedRoute,
         private taskdata: TaskDataService,

--- a/libs/task-design/src/components/task-detail/task-detail.scss
+++ b/libs/task-design/src/components/task-detail/task-detail.scss
@@ -46,7 +46,6 @@
 @media (max-width: 768px) {
     .detail-card {
         .detail-img {
-            width: 100%;
             height: 90px;
         }
     }


### PR DESCRIPTION
So turns out the justify-content was causing task cards with less content to be squashed. Now all detail cards use margin 0px auto; to set the borders on the sides which is then filled by the card. 